### PR TITLE
Update links of highlight groups from `Statement` to meaningful ones

### DIFF
--- a/after/syntax/javascript.vim
+++ b/after/syntax/javascript.vim
@@ -86,10 +86,10 @@ syntax match   javascriptNumber                /[+-]\=[_0-9]\+\.\%([eE][+-]\=[_0
 syntax match   javascriptNonNumber             /\%(\<\|\.\|e\)_[_0-9]\+\|[_0-9]\+_\%(\>\|\.\|e\|n\)/ nextgroup=@javascriptComments skipwhite skipempty
 
 if exists("did_javascript_hilink")
-  HiLink javascriptDecorator           Statement
-  HiLink javascriptDecoratorFuncName   Statement
+  HiLink javascriptDecorator           Operator
+  HiLink javascriptDecoratorFuncName   Function
   HiLink javascriptDecoratorFuncCall   Statement
-  HiLink javascriptDecoratorParens     Statement
+  HiLink javascriptDecoratorParens     javascriptParens
 
   HiLink javascriptClassProperty       Normal
 


### PR DESCRIPTION
I noticed that every highlight group of this was linked to `Statement`
which rendered them kinda useless plus `Statement` doesn't fit for any
of them except for the `,` in the parameter list.